### PR TITLE
Request handling changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
+.idea
 out

--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -5,10 +5,11 @@ use {
         env,
         fs::{self, File},
         io::Write,
-        os::unix,
         path::{Path, PathBuf},
     },
 };
+#[cfg(target_family = "unix")]
+use std::os::unix;
 
 /// You should use the
 /// [`vial::bundle_assets!()`](macro.bundle_assets.html) macro instead
@@ -82,7 +83,8 @@ fn files_in_dir(path: &str) -> Result<Vec<PathBuf>> {
         let path = entry.path();
         let meta = fs::metadata(&path)?;
         if meta.is_dir() {
-            files.extend_from_slice(&files_in_dir(path.to_str().unwrap_or("bad"))?);
+            let dir = path.to_string_lossy() + "/";
+            files.extend_from_slice(&files_in_dir(dir.as_ref())?);
         } else {
             files.push(path);
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,8 @@ pub enum Error {
     ParseHeaderName,
     /// Failed to parse HTTP header value.
     ParseHeaderValue,
+    /// Failed to parse HTTP path value.
+    ParsePath,
     /// Failed to parse HTTP request.
     ParseError,
     /// io::Error
@@ -54,6 +56,7 @@ impl fmt::Display for Error {
             match self {
                 Error::UnknownHTTPMethod(reason) => reason,
                 Error::ConnectionClosed => "Connection Closed By Client",
+                Error::ParsePath => "Error Parsing HTTP Path",
                 Error::ParseVersion => "Error Parsing HTTP Version",
                 Error::ExpectedCRLF => "Expected CRLF in HTTP Request",
                 Error::ParseHeaderName => "Error Parsing HTTP Header name",
@@ -91,6 +94,7 @@ impl PartialEq for Error {
                 _ => false,
             },
             ConnectionClosed => matches!(other, ConnectionClosed),
+            ParsePath => matches!(other, ParsePath),
             ParseVersion => matches!(other, ParseVersion),
             ExpectedCRLF => matches!(other, ExpectedCRLF),
             ParseHeaderName => matches!(other, ParseHeaderName),

--- a/src/http_parser.rs
+++ b/src/http_parser.rs
@@ -1,199 +1,215 @@
-use crate::{request::Span, Error, Request};
-
-/// Status of parsing an HTTP request. The request may have been only
-/// partial, in which case the buffer is returned in `Partial` so we
-/// can continue reading from the socket.
-#[derive(Debug)]
-pub enum Status {
-    Complete(Request),
-    Partial(Vec<u8>),
-}
+use crate::{Error, Request, request::Span};
+use crate::error::Error::ConnectionClosed;
 
 /// Total size limit for all headers combined.
 const MAX_HEADER_SIZE: usize = 8192;
 
 /// Parse a raw HTTP request into a Request struct.
-pub fn parse(mut buffer: Vec<u8>) -> Result<Status, Error> {
+pub fn parse(buffer: Vec<u8>) -> Result<Request, Error> {
     let mut pos = 0;
 
-    // clear preceding \n or \r
-    while !buffer.is_empty() && buffer[0].is_ascii_whitespace() {
-        buffer.remove(0);
-    }
-
-    macro_rules! need {
+    macro_rules! peek {
         ($size:expr) => {
             if buffer[pos..].len() < $size {
-                return Ok(Status::Partial(buffer));
+                return Err(Error::ConnectionClosed);
             } else {
                 true
             }
         };
     }
 
-    need!(10);
+    macro_rules! consume_whitespace {
+        () => {
+            while peek!(1) && buffer[pos].is_ascii_whitespace() {
+                pos += 1;
+            }
+        };
+    }
 
-    // Parse method: GET / HTTP/1.1
-    let method_len = {
-        match &buffer[0..3] {
-            b"GET" | b"PUT" => 3,
-            b"HEA" | b"POS" => match &buffer[0..4] {
-                b"HEAD" | b"POST" => 4,
-                _ => 0,
-            },
-            b"PAT" | b"TRA" => match &buffer[0..5] {
-                b"PATCH" | b"TRACE" => 5,
-                _ => 0,
-            },
-            b"DEL" => {
-                if &buffer[0..6] == b"DELETE" {
-                    6
+    macro_rules! consume_whitespace_to_eol {
+        () => {
+            while buffer[pos].is_ascii_whitespace() && (buffer[pos] != b'\r' && buffer[pos] != b'\n') {
+                if !peek!(1) {
+                    break
+                }
+                pos += 1;
+            }
+        };
+    }
+
+    macro_rules! consume {
+        ($word:expr) => {
+            consume!($word, false)
+        };
+        ($word:expr, $error:expr) => {
+            let mut found = true;
+            for c in $word.bytes() {
+                if buffer.len() <= pos {
+                    return Err(Error::ConnectionClosed);
+                } else if buffer[pos] == c {
+                    pos += 1;
                 } else {
-                    0
+                    found = false;
+                    break
                 }
             }
-            b"CON" | b"OPT" => match &buffer[0..7] {
-                b"CONNECT" | b"OPTIONS" => 7,
-                _ => 0,
-            },
-            _ => 0,
-        }
-    };
-
-    if method_len == 0 {
-        return Err(Error::UnknownHTTPMethod("?".into()));
+            if found {
+                true
+            } else {
+                $error
+            }
+        };
     }
 
-    if buffer[method_len] != b' ' {
-        return Err(Error::ParseError);
+    macro_rules! consume_eol {
+        () => {
+            consume_eol!(false)
+        };
+        ($error:expr) => {
+            if (peek!(1) && buffer[pos] == b'\n') {
+                pos += 1;
+                true
+            } else if (peek!(2) && &buffer[pos..pos + 2] == b"\r\n") {
+                pos += 2;
+                true
+            } else {
+                $error
+            }
+        };
     }
 
-    // Parse path: GET / HTTP/1.1
-    let path_len = buffer[method_len + 1..].iter().position(|c| *c == b' ');
-    if path_len.is_none() {
-        return Ok(Status::Partial(buffer));
-    }
-    let path_len = path_len.unwrap();
-    pos = method_len + 1 + path_len + 1;
+    consume_whitespace!();
+    let method = parse_method(&buffer, &mut pos)?;
 
-    // Parse version: GET / HTTP/1.1
-    for c in b"HTTP/1.1" {
-        if buffer.len() <= pos {
-            return Ok(Status::Partial(buffer));
-        } else if buffer[pos] == *c {
-            pos += 1;
-        } else {
-            return Err(Error::ParseVersion);
-        }
-    }
+    consume!(" ", return Err(Error::ParseError));
+    let path = parse_path(&buffer, &mut pos)?;
 
-    // Parse first line break
-    if need!(1) && buffer[pos] == b'\n' {
-        pos += 1;
-    } else if need!(2) && &buffer[pos..pos + 2] == b"\r\n" {
-        pos += 2;
-    } else {
-        return Err(Error::ExpectedCRLF);
-    }
+    consume!(" ", return Err(Error::ParseError));
+    consume!("HTTP/1.1", return Err(Error::ParseVersion));
+    consume_eol!(return Err(Error::ExpectedCRLF));
 
-    // End here if there are no headers.
-    if (need!(1) && buffer[pos] == b'\n') || (need!(2) && &buffer[pos..pos + 2] == b"\r\n") {
-        let method = Span(0, method_len);
-        let path = Span(method_len + 1, method_len + 1 + path_len);
-
-        return Ok(Status::Complete(Request::new(
+    // Expecting Headers but if there's another EOL we're done and we can just return the struct
+    if consume_eol!() {
+        return Ok(Request::new(
             method,
             path,
             Vec::new(),
             Span::new(),
             buffer,
-        )));
+        ));
     }
 
     // Parse headers
-    let mut start = pos;
+    let start = pos;
     let mut headers = Vec::with_capacity(16);
-    let mut name = Span::new();
-    let mut saw_end = false;
-    let mut parsing_key = true;
     let mut content_length = 0;
-    let mut len = 0; // header length
 
-    while let Some(c) = buffer.get(pos) {
-        if parsing_key {
-            match *c {
-                b':' => {
-                    name = Span(start, pos);
-                    // skip leading whitespace on value
-                    while let Some(&b' ') | Some(&b'\t') = buffer.get(pos + 1) {
-                        pos += 1;
-                    }
-                    parsing_key = false;
-                    start = pos + 1;
-                }
-                b'\r' | b'\n' | b' ' | b'\t' => return Err(Error::ParseHeaderName),
-                _ => {}
-            }
-        } else if *c == b'\n' || (*c == b'\r' && buffer.get(pos + 1) == Some(&b'\n')) {
-            if name.is_empty() {
-                return Err(Error::ParseError);
-            }
+    loop {
+        let name = parse_header_name(&buffer, &mut pos)?;
+        consume!(":");
+        consume_whitespace_to_eol!();
+        let value = parse_header_value(&buffer, &mut pos)?;
 
-            let value = Span(start, pos);
-            headers.push((name, value));
-            if name.from_buf(&buffer).to_ascii_lowercase() == "content-length" {
-                content_length = value.from_buf(&buffer).parse().unwrap_or(0);
-            }
-
-            name = Span::new();
-            parsing_key = true;
-
-            // skip \r\n or \n
-            pos += if *c == b'\n' { 1 } else { 2 };
-
-            if let Some(next) = buffer.get(pos) {
-                match *next {
-                    b'\n' => {
-                        pos += 1;
-                        saw_end = true;
-                        break;
-                    }
-                    b'\r' => {
-                        if buffer.get(pos + 1) != Some(&b'\n') {
-                            return Ok(Status::Partial(buffer));
-                        }
-                        pos += 2;
-                        saw_end = true;
-                        break;
-                    }
-                    _ => {}
-                }
-            }
-
-            start = pos;
-            continue;
+        if name.from_buf(&buffer).to_ascii_lowercase() == "content-length" {
+            content_length = value.from_buf(&buffer).parse().unwrap_or(0);
         }
-        len += 1;
-        if len > MAX_HEADER_SIZE {
+        headers.push((name, value));
+
+        consume_eol!(return Err(Error::ConnectionClosed));
+
+        if consume_eol!() {
+            break;
+        }
+        if pos - start > MAX_HEADER_SIZE {
             return Err(Error::ParseHeaderValue);
         }
-        pos += 1;
     }
 
-    // didn't receive full headers, abort
-    if !saw_end {
-        return Ok(Status::Partial(buffer));
-    }
-
-    let method = Span(0, method_len);
-    let path = Span(method_len + 1, method_len + 1 + path_len);
     let body = if content_length > 0 {
-        Span(pos, pos + buffer.len())
+        Span(pos, pos + content_length)
     } else {
         Span::new()
     };
 
-    Ok(Status::Complete(Request::new(
+    if body.1 > buffer.len() {
+        return Err(ConnectionClosed);
+    }
+
+    Ok(Request::new(
         method, path, headers, body, buffer,
-    )))
+    ))
+}
+
+fn parse_method(buffer: &Vec<u8>, pos: &mut usize) -> Result<Span, Error> {
+    let start = *pos;
+    let size = match &buffer[start..start + 3] {
+        b"GET" | b"PUT" => 3,
+        b"HEA" | b"POS" => match &buffer[start..start + 4] {
+            b"HEAD" | b"POST" => 4,
+            _ => 0,
+        },
+        b"PAT" | b"TRA" => match &buffer[start..start + 5] {
+            b"PATCH" | b"TRACE" => 5,
+            _ => 0,
+        },
+        b"DEL" => {
+            if &buffer[0..6] == b"DELETE" {
+                6
+            } else {
+                0
+            }
+        }
+        b"CON" | b"OPT" => match &buffer[start..start + 7] {
+            b"CONNECT" | b"OPTIONS" => 7,
+            _ => 0,
+        },
+        _ => 0,
+    };
+    if size == 0 {
+        Err(Error::UnknownHTTPMethod("?".into()))
+    } else {
+        *pos += size;
+        Ok(Span(start, start + size))
+    }
+}
+
+fn parse_path(buffer: &Vec<u8>, pos: &mut usize) -> Result<Span, Error> {
+    let start = *pos;
+    let end = buffer[start..].iter().position(|c| *c == b' ');
+    let end = match end {
+        Some(number) => number,
+        None => 0
+    };
+    if end == 0 {
+        return Err(Error::ParsePath);
+    };
+    *pos += end;
+    Ok(Span(start, start + end))
+}
+
+fn parse_header_name(buffer: &Vec<u8>, pos: &mut usize) -> Result<Span, Error> {
+    let start = *pos;
+    loop {
+        match buffer[*pos] {
+            b':' => break,
+            b'\r' | b'\n' | b' ' | b'\t' => return Err(Error::ParseHeaderName),
+            _ => {
+                *pos += 1;
+                if *pos == buffer.len() {
+                    return Err(Error::ParseHeaderName);
+                }
+            }
+        }
+    };
+    let end = *pos;
+    Ok(Span(start, end))
+}
+
+fn parse_header_value(buffer: &Vec<u8>, pos: &mut usize) -> Result<Span, Error> {
+    let start = *pos;
+    while *pos < buffer.len() && (buffer[*pos] != b'\r' && buffer[*pos] != b'\n') {
+        *pos += 1;
+    }
+    let end = *pos;
+    Ok(Span(start, end))
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,3 +1,4 @@
+use std::net::TcpStream;
 use {
     crate::{http_parser, util, Error, Result, TypeCache},
     std::{borrow::Cow, collections::HashMap, fmt, io, mem, rc::Rc, str},
@@ -19,7 +20,7 @@ impl Span {
 
     /// Is this span empty?
     pub fn is_empty(&self) -> bool {
-        self.0 == 0 && self.1 == 0
+        self.0 == self.1
     }
 
     /// Find and return the str this span represents from the given
@@ -124,34 +125,21 @@ impl Request {
     /// appropriate `Request` to represent it.
     pub fn from_reader<R: io::Read>(mut reader: R) -> Result<Request> {
         let mut buffer = Vec::with_capacity(512);
-        let mut read_buf = [0u8; 512];
-
-        let mut req = loop {
-            let n = reader.read(&mut read_buf)?;
-            if n == 0 {
-                return Err(Error::ConnectionClosed);
-            }
-            buffer.extend_from_slice(&read_buf[..n]);
-            match http_parser::parse(std::mem::take(&mut buffer))? {
-                http_parser::Status::Complete(req) => break req,
-                http_parser::Status::Partial(b) => {
-                    let _ = mem::replace(&mut buffer, b);
+        loop {
+            match reader.read_to_end(&mut buffer) {
+                Ok(_) => break,
+                Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    if buffer.len() > 0 {
+                        break;
+                    }
                 }
-            }
+                Err(e) => return Err(Error::IO(e)),
+            };
         };
 
-        if let Some(size) = req.header("Content-Length") {
-            let size = size.parse().unwrap_or(0);
-            let start = req.body.0;
+        let mut req = http_parser::parse(mem::replace(&mut buffer, vec![]))?;
 
-            while req.buffer[start..].len() < size {
-                let n = reader.read(&mut read_buf)?;
-                if n == 0 {
-                    break;
-                }
-                req.buffer.extend_from_slice(&read_buf[..n]);
-            }
-            req.body.1 = req.body.0 + size;
+        if req.header("Content-Length").is_some() {
             req.parse_form();
         }
 
@@ -170,6 +158,13 @@ impl Request {
         }
 
         Ok(req)
+    }
+
+    /// Read a raw HTTP request from `TcpStream` and create an
+    /// appropriate `Request` to represent it.
+    pub fn from_stream( stream: &TcpStream) -> Result<Request> {
+        stream.set_nonblocking(true)?;
+        Request::from_reader(stream)
     }
 
     /// Sets the remote address of the request.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use {
     crate::{asset, Request, Response, Result, Router},
     std::{
@@ -65,6 +66,8 @@ impl Server {
 
     fn handle_request(&self, stream: TcpStream) -> Result<()> {
         let stream = stream.try_clone()?;
+        //discard because: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.set_read_timeout
+        let _ = stream.set_read_timeout(Some(Duration::from_millis(1000)));
         let mut req = Request::from_stream(&stream)?;
         req.set_remote_addr(stream.peer_addr()?.to_string());
         self.write_response(stream, req)

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,7 +4,6 @@ use {
         io::Write,
         net::{TcpListener, TcpStream, ToSocketAddrs},
         sync::{Arc, Mutex},
-        time::Duration,
     },
     threadpool::ThreadPool,
 };
@@ -65,11 +64,8 @@ impl Server {
     }
 
     fn handle_request(&self, stream: TcpStream) -> Result<()> {
-        let reader = stream.try_clone()?;
-        //discard because: https://doc.rust-lang.org/std/net/struct.TcpStream.html#method.set_read_timeout
-        let _ = reader.set_read_timeout(Some(Duration::from_millis(1000)));
-
-        let mut req = Request::from_reader(reader)?;
+        let stream = stream.try_clone()?;
+        let mut req = Request::from_stream(&stream)?;
         req.set_remote_addr(stream.peer_addr()?.to_string());
         self.write_response(stream, req)
     }

--- a/tests/cookies_test.rs
+++ b/tests/cookies_test.rs
@@ -2,7 +2,7 @@
 
 use std::{fs, fs::File};
 use vial::{
-    http_parser::{parse, Status},
+    http_parser::parse,
     Error, Request,
 };
 
@@ -14,12 +14,11 @@ fn fixture(name: &str) -> String {
 }
 
 fn parse_fixture(name: &str) -> Request {
-    let x = parse(fixture(name).as_bytes().to_vec());
-    println!("{:?}", x);
-
-    match x.unwrap() {
-        Status::Complete(request) => request,
-        _ => panic!("Expected Status::Complete"),
+    let parse_result = parse(fixture(name).as_bytes().to_vec());
+    println!("{:?}", parse_result);
+    match parse_result {
+        Ok(request) => request,
+        Err(error) => panic!("Error with request!"),
     }
 }
 

--- a/tests/http_parser_test.rs
+++ b/tests/http_parser_test.rs
@@ -2,7 +2,7 @@
 
 use std::fs;
 use vial::{
-    http_parser::{parse, Status},
+    http_parser::parse,
     Error, Request,
 };
 
@@ -14,8 +14,8 @@ fn fixture(name: &str) -> String {
 }
 
 fn parse_fixture(name: &str) -> Request {
-    match parse(fixture(name).as_bytes().to_vec()).unwrap() {
-        Status::Complete(request) => request,
+    match parse(fixture(name).as_bytes().to_vec()) {
+        Ok(request) => request,
         _ => panic!("Expected Status::Complete"),
     }
 }

--- a/tests/httparse_test.rs
+++ b/tests/httparse_test.rs
@@ -2,7 +2,7 @@
 // https://github.com/seanmonstar/httparse/blob/master/tests/uri.rs
 
 use vial::{
-    http_parser::{parse, Status},
+    http_parser::parse,
     Error,
 };
 
@@ -11,15 +11,15 @@ macro_rules! test {
         #[test]
         fn $name() {
             use vial::{
-                http_parser::{parse, Status},
+                http_parser::parse,
                 Request,
             };
 
-            let req = match parse($buf.to_vec()).unwrap() {
-                Status::Complete(request) => request,
-                Status::Partial(buf) => panic!(
-                    "Expected Status::Complete, got Status::Partial({})",
-                    buf.len()
+            let req = match parse($buf.to_vec()) {
+                Ok(request) => request,
+                Err(e) => panic!(
+                    "Expected Status::Complete, got Err - {})",
+                    e
                 ),
             };
             closure(req);
@@ -104,7 +104,7 @@ test! {
 test! {
     urltest_007,
     b"GET  foo.com HTTP/1.1\r\nHost: \r\n\r\n",
-    Error::ParseVersion
+    Error::ParsePath
 }
 
 test! {
@@ -2814,7 +2814,7 @@ test! {
 #[test]
 fn test_request_partial() {
     match parse(b"GET / HTTP/1.1\r\n\r".to_vec()) {
-        Ok(Status::Partial(..)) => assert!(true),
+        Err(Error::ConnectionClosed) => assert!(true),
         _ => assert!(false),
     }
 }
@@ -2822,7 +2822,7 @@ fn test_request_partial() {
 #[test]
 fn test_request_partial_version() {
     match parse(b"GET / HTTP/1.".to_vec()) {
-        Ok(Status::Partial(..)) => assert!(true),
+        Err(Error::ConnectionClosed)=> assert!(true),
         _ => assert!(false),
     }
 }

--- a/tests/util_test.rs
+++ b/tests/util_test.rs
@@ -57,7 +57,13 @@ fn http_current_date() {
 
 #[test]
 fn file_size() {
-    assert_eq!(1052, util::file_size("LICENSE-MIT"));
-    assert_eq!(25161, util::file_size("tests/assets/rfcs/rfc1288.txt"));
+    #[cfg(target_family = "windows")] {
+        assert_eq!(1072, util::file_size("LICENSE-MIT"));
+        assert_eq!(25835, util::file_size("tests/assets/rfcs/rfc1288.txt"));
+    }
+    #[cfg(target_family = "unix")] {
+        assert_eq!(1052, util::file_size("LICENSE-MIT"));
+        assert_eq!(25161, util::file_size("tests/assets/rfcs/rfc1288.txt"));
+    }
     assert_eq!(0, util::file_size("LICENSE-MADE-UP"));
 }


### PR DESCRIPTION
I took a different approach to your timeout mechanism and went with implementing a non-blocking stream. I then polled for the entire contents of the request before parsing.

The idea behind this was to prevent the parser from stopping the parsing process, kicking back the request for more data, and then restarting the process from the beginning.  This works great but it resulted in a number of changes.

Since we have the full request from the beginning, there is no need for a http_parse::Status as there is never a partial status. Either we received the full request, or the connection was assumed to be closed prematurely. This changes some of the tests that were expecting a partial result versus a connection-closed.

The determination of whether the body was completely sent was moved into the parser. 

Rather than relying on the caller of the Request to remember to set the stream to non-blocking, I added a new method to Request set that when parsing from the stream.

As part of this, I ended up restructuring the parser so that I could understand the parsing process better which is where I found a subtle problem with how it was handling the path validation. Which I clarified by adding a new ParsePath error. 

This is large PR and I'm fairly new to Rust. So I'd appreciate any feedback.