### PR TITLE
Threadfin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ default = []
 compression = ['libflate', 'brotli2', 'zstd', 'http', 'fly-accept-encoding']
 
 [dependencies]
-threadpool = "1.7.1"
+threadfin = "0.1.0"
 libc-strftime = "0.2.0"
 
 basic-cookies = { version = "0.1.4", optional = true }

--- a/src/server.rs
+++ b/src/server.rs
@@ -15,7 +15,8 @@ use {
 /// that needs to happen.
 #[doc(hidden)]
 pub fn run<T: ToSocketAddrs>(addr: T, router: Router, banner: Option<&str>) -> Result<()> {
-    let pool = threadfin::builder().size(8).build();
+    // If a range is supplied, the lower bound will be the core pool size while the upper bound will be a maximum pool size the pool is allowed to burst up to when the core threads are busy.
+    let pool = threadfin::builder().size(1..=128).build();
     let listener = TcpListener::bind(&addr)?;
     let addr = listener.local_addr()?;
     let server = Arc::new(Server::new(router));

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,16 +10,12 @@ use {
     }
 };
 
-const INITIAL_THREADS: usize = 10;
-const MAXIMUM_THREADS: usize = 400;
-
 /// Starts a new Vial server. Should always be invoked via the
 /// [`vial::run!()`](macro.run.html) macro, since there is some setup
 /// that needs to happen.
 #[doc(hidden)]
 pub fn run<T: ToSocketAddrs>(addr: T, router: Router, banner: Option<&str>) -> Result<()> {
-    // let mut pool = ThreadPool::new(INITIAL_THREADS);
-    let mut pool = threadfin::builder().size(8).build();
+    let pool = threadfin::builder().size(8).build();
     let listener = TcpListener::bind(&addr)?;
     let addr = listener.local_addr()?;
     let server = Arc::new(Server::new(router));

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,8 +7,7 @@ use {
         io::Write,
         net::{TcpListener, TcpStream, ToSocketAddrs},
         sync::{Arc, Mutex},
-    },
-    threadpool::ThreadPool,
+    }
 };
 
 const INITIAL_THREADS: usize = 10;
@@ -19,7 +18,8 @@ const MAXIMUM_THREADS: usize = 400;
 /// that needs to happen.
 #[doc(hidden)]
 pub fn run<T: ToSocketAddrs>(addr: T, router: Router, banner: Option<&str>) -> Result<()> {
-    let mut pool = ThreadPool::new(INITIAL_THREADS);
+    // let mut pool = ThreadPool::new(INITIAL_THREADS);
+    let mut pool = threadfin::builder().size(8).build();
     let listener = TcpListener::bind(&addr)?;
     let addr = listener.local_addr()?;
     let server = Arc::new(Server::new(router));
@@ -35,16 +35,6 @@ pub fn run<T: ToSocketAddrs>(addr: T, router: Router, banner: Option<&str>) -> R
     }
 
     for stream in listener.incoming() {
-        // if all threads are active, extend by two
-        if pool.active_count() > pool.max_count() - 1 && pool.max_count() < MAXIMUM_THREADS {
-            pool.set_num_threads(pool.max_count() + 2);
-        }
-        // tldr: if no active threads and the threadpool has
-        // been expanded, halve the total number of threads.
-        if pool.active_count() == 0 && pool.max_count() > INITIAL_THREADS * 2 {
-            pool.set_num_threads(pool.max_count() / 2);
-        }
-
         let server = server.clone();
         let stream = stream?;
         pool.execute(move || {


### PR DESCRIPTION
Closes #13 
This gets rid of the very hacky threadpool resizing. Currently set to `1..=128` inclusive meaning by default one thread will be made, but up to 128 will be spawned if necessary.